### PR TITLE
Setting consent cookie for cookieDomain (allowing for subdomains)

### DIFF
--- a/jquery.cookiecuttr.js
+++ b/jquery.cookiecuttr.js
@@ -220,11 +220,13 @@
             e.preventDefault();
             if ($(this).is('[href$=#decline]')) {
                 $.cookie("cc_cookie_accept", null, {
-                    path: '/'
+                    path: '/',
+                    domain: options.cookieDomain
                 });
                 $.cookie("cc_cookie_decline", "cc_cookie_decline", {
                     expires: cookieExpires,
-                    path: '/'
+                    path: '/',
+                    domain: options.cookieDomain
                 });
                 if (options.cookieDomain) {
                     // kill google analytics cookies

--- a/jquery.cookiecuttr.js
+++ b/jquery.cookiecuttr.js
@@ -247,11 +247,13 @@
                 }
             } else {
                 $.cookie("cc_cookie_decline", null, {
-                    path: '/'
+                    path: '/',
+                    domain: options.cookieDomain
                 });
                 $.cookie("cc_cookie_accept", "cc_cookie_accept", {
                     expires: cookieExpires,
-                    path: '/'
+                    path: '/',
+                    domain: options.cookieDomain
                 });
             }
             $(".cc-cookies").fadeOut(function () {
@@ -263,10 +265,12 @@
         $('a.cc-cookie-reset').click(function (f) {
             f.preventDefault();
             $.cookie("cc_cookie_accept", null, {
-                path: '/'
+                path: '/',
+                domain: options.cookieDomain
             });
             $.cookie("cc_cookie_decline", null, {
-                path: '/'
+                path: '/',
+                domain: options.cookieDomain
             });
             $(".cc-cookies").fadeOut(function () {
                 // reload page to activate cookies
@@ -278,10 +282,12 @@
             g.preventDefault();
             $.cookie("cc_cookie_accept", "cc_cookie_accept", {
                 expires: cookieExpires,
-                path: '/'
+                path: '/',
+                domain: options.cookieDomain
             });
             $.cookie("cc_cookie_decline", null, {
-                path: '/'
+                path: '/',
+                domain: options.cookieDomain
             });
             // reload page to activate cookies
             location.reload();


### PR DESCRIPTION
When cookieDomain is specified as an option for cookieCuttr the consent cookie will be set for the given domain. Visitors don't have to accept cookies for each subdomain anymore.
