### PR TITLE
Changable cookie names and values

### DIFF
--- a/jquery.cookiecuttr.js
+++ b/jquery.cookiecuttr.js
@@ -50,15 +50,19 @@
             cookieDiscreetLinkText          : "Cookies?",
             cookieDiscreetPosition          : "topleft", //options: topleft, topright, bottomleft, bottomright
             cookieNoMessage                 : false, // change to true hide message from all pages apart from your policy page
-            cookieDomain                    : ""
+            cookieDomain                    : "",
+            cookieAcceptName                : 'cc_cookie_accept',
+            cookieAcceptValue               : 'cc_cookie_accept',
+            cookieDeclineName               : 'cc_cookie_decline',
+            cookieDeclineValue              : 'cc_cookie_decline'
         };
 
         options               = $.extend({}, defaults, options);
         options.cookieMessage = options.cookieMessage.replace('{{cookiePolicyLink}}', options.cookiePolicyLink);
 
         // cookie identifier
-        var $cookieAccepted = $.cookie('cc_cookie_accept')  == 'cc_cookie_accept';
-        var $cookieDeclined = $.cookie('cc_cookie_decline') == 'cc_cookie_decline';
+        var $cookieAccepted = $.cookie(options.cookieAcceptName)  == options.cookieAcceptValue;
+        var $cookieDeclined = $.cookie(options.cookieDeclineName) == options.cookieDeclineValue;
 
         $.cookieAccepted = function () { return $cookieAccepted; };
         $.cookieDeclined = function () { return $cookieDeclined; };
@@ -127,15 +131,13 @@
             (options.cookieNotificationLocationBottom && options.cookieDiscreetLink && options.cookiePolicyPage)
         ) $('div.cc-cookies').css({top: 'auto', bottom: 0});
 
-        // click handlers, setting the cookies ...
-
         // handler: for [top/bottom] bar
         $('.cc-cookie-accept, .cc-cookie-decline').click(function (e) {
             e.preventDefault();
 
             if ($(this).is('[href$=#decline]')) {
-                $.cookie('cc_cookie_accept', null, { path: '/' });
-                $.cookie('cc_cookie_decline', 'cc_cookie_decline', { expires: options.cookieExpires, path: '/'});
+                $.cookie(options.cookieAcceptName, null, { path: '/' });
+                $.cookie(options.cookieDeclineName, options.cookieDeclineValue, { expires: options.cookieExpires, path: '/'});
 
                 if (options.cookieDomain) {
                     // kill google analytics cookies
@@ -145,8 +147,8 @@
                     $.cookie("__utmz", null, { domain: '.' + options.cookieDomain, path: '/' });
                 }
             } else {
-                $.cookie('cc_cookie_decline', null, { path: '/' });
-                $.cookie('cc_cookie_accept', 'cc_cookie_accept', { expires: options.cookieExpires, path: '/' });
+                $.cookie(options.cookieDeclineName, null, { path: '/' });
+                $.cookie(options.cookieAcceptName, options.cookieAcceptValue, { expires: options.cookieExpires, path: '/' });
             }
 
             $(".cc-cookies").fadeOut(function () {
@@ -158,8 +160,8 @@
         $('a.cc-cookie-reset').click(function (f) {
             f.preventDefault();
 
-            $.cookie('cc_cookie_accept', null,  { path: '/' });
-            $.cookie('cc_cookie_decline', null, { path: '/' });
+            $.cookie(options.cookieAcceptName, null,  { path: '/' });
+            $.cookie(options.cookieDeclineName, null, { path: '/' });
 
             $(".cc-cookies").fadeOut(function () {
                 location.reload();
@@ -170,8 +172,8 @@
         $('.cc-cookies-error a.cc-cookie-accept').click(function (g) {
             g.preventDefault();
 
-            $.cookie('cc_cookie_accept', 'cc_cookie_accept', { expires: options.cookieExpires, path: '/'});
-            $.cookie('cc_cookie_decline', null, { path: '/'});
+            $.cookie(options.cookieAcceptName, options.cookieAcceptValue, { expires: options.cookieExpires, path: '/'});
+            $.cookie(options.cookieDeclineName, null, { path: '/'});
 
             location.reload();
         });

--- a/jquery.cookiecuttr.js
+++ b/jquery.cookiecuttr.js
@@ -5,7 +5,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT
  * HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR
@@ -14,276 +14,165 @@
  * COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.COPYRIGHT HOLDERS WILL NOT
  * BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL
  * DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENTATION.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://gnu.org/licenses/>.
- 
+
  Documentation available at http://cookiecuttr.com
- 
+
  */
 (function ($) {
     $.cookieCuttr = function (options) {
         var defaults = {
-            cookieCutter: false, // you'd like to enable the div/section/span etc. hide feature? change this to true
-            cookieCutterDeclineOnly: false, // you'd like the CookieCutter to only hide when someone has clicked declined set this to true
-            cookieAnalytics: true, // just using a simple analytics package? change this to true
-            cookieDeclineButton: false, // this will disable non essential cookies
-            cookieAcceptButton: true, // this will disable non essential cookies
-            cookieResetButton: false,
-            cookieOverlayEnabled: false, // don't want a discreet toolbar? Fine, set this to true
-            cookiePolicyLink: '/privacy-policy/', // if applicable, enter the link to your privacy policy here...
-            cookieMessage: 'We use cookies on this website, you can <a href="{{cookiePolicyLink}}" title="read about our cookies">read about them here</a>. To use the website as intended please...',
-            cookieAnalyticsMessage: 'We use cookies, just to track visits to our website, we store no personal details.',
-            cookieErrorMessage: "We\'re sorry, this feature places cookies in your browser and has been disabled. <br>To continue using this functionality, please",
-            cookieWhatAreTheyLink: "http://www.allaboutcookies.org/",
-            cookieDisable: '',
-            cookieExpires: 365,
-            cookieAcceptButtonText: "ACCEPT COOKIES",
-            cookieDeclineButtonText: "DECLINE COOKIES",
-            cookieResetButtonText: "RESET COOKIES FOR THIS WEBSITE",
-            cookieWhatAreLinkText: "What are cookies?",
-            cookieNotificationLocationBottom: false, // top or bottom - they are your only options, so true for bottom, false for top            
-            cookiePolicyPage: false,
-            cookiePolicyPageMessage: 'Please read the information below and then choose from the following options',
-            cookieDiscreetLink: false,
-            cookieDiscreetReset: false,
-            cookieDiscreetLinkText: "Cookies?",
-            cookieDiscreetPosition: "topleft", //options: topleft, topright, bottomleft, bottomright         
-            cookieNoMessage: false, // change to true hide message from all pages apart from your policy page
-            cookieDomain: ""
+            cookieCutter                    : false, // you'd like to enable the div/section/span etc. hide feature? change this to true
+            cookieCutterDeclineOnly         : false, // you'd like the CookieCutter to only hide when someone has clicked declined set this to true
+            cookieAnalytics                 : true, // just using a simple analytics package? change this to true
+            cookieDeclineButton             : false, // this will disable non essential cookies
+            cookieAcceptButton              : true, // this will disable non essential cookies
+            cookieResetButton               : false,
+            cookieOverlayEnabled            : false, // don't want a discreet toolbar? Fine, set this to true
+            cookiePolicyLink                : '/privacy-policy/', // if applicable, enter the link to your privacy policy here...
+            cookieMessage                   : 'We use cookies on this website, you can <a href="{{cookiePolicyLink}}" title="read about our cookies">read about them here</a>. To use the website as intended please...',
+            cookieAnalyticsMessage          : 'We use cookies, just to track visits to our website, we store no personal details.',
+            cookieErrorMessage              : "We\'re sorry, this feature places cookies in your browser and has been disabled. <br>To continue using this functionality, please",
+            cookieWhatAreTheyLink           : "http://www.allaboutcookies.org/",
+            cookieDisable                   : '',
+            cookieExpires                   : 365,
+            cookieAcceptButtonText          : "ACCEPT COOKIES",
+            cookieDeclineButtonText         : "DECLINE COOKIES",
+            cookieResetButtonText           : "RESET COOKIES FOR THIS WEBSITE",
+            cookieWhatAreLinkText           : "What are cookies?",
+            cookieNotificationLocationBottom: false, // top or bottom - they are your only options, so true for bottom, false for top
+            cookiePolicyPage                : false,
+            cookiePolicyPageMessage         : 'Please read the information below and then choose from the following options',
+            cookieDiscreetLink              : false,
+            cookieDiscreetReset             : false,
+            cookieDiscreetLinkText          : "Cookies?",
+            cookieDiscreetPosition          : "topleft", //options: topleft, topright, bottomleft, bottomright
+            cookieNoMessage                 : false, // change to true hide message from all pages apart from your policy page
+            cookieDomain                    : ""
         };
-        var options = $.extend(defaults, options);
-        var message = defaults.cookieMessage.replace('{{cookiePolicyLink}}', defaults.cookiePolicyLink);
-        defaults.cookieMessage = 'We use cookies on this website, you can <a href="' + defaults.cookiePolicyLink + '" title="read about our cookies">read about them here</a>. To use the website as intended please...';
-        //convert options
-        var cookiePolicyLinkIn = options.cookiePolicyLink;
-        var cookieCutter = options.cookieCutter;
-        var cookieCutterDeclineOnly = options.cookieCutterDeclineOnly;
-        var cookieAnalytics = options.cookieAnalytics;
-        var cookieDeclineButton = options.cookieDeclineButton;
-        var cookieAcceptButton = options.cookieAcceptButton;
-        var cookieResetButton = options.cookieResetButton;
-        var cookieOverlayEnabled = options.cookieOverlayEnabled;
-        var cookiePolicyLink = options.cookiePolicyLink;
-        var cookieMessage = message;
-        var cookieAnalyticsMessage = options.cookieAnalyticsMessage;
-        var cookieErrorMessage = options.cookieErrorMessage;
-        var cookieDisable = options.cookieDisable;
-        var cookieWhatAreTheyLink = options.cookieWhatAreTheyLink;
-        var cookieExpires = options.cookieExpires;
-        var cookieAcceptButtonText = options.cookieAcceptButtonText;
-        var cookieDeclineButtonText = options.cookieDeclineButtonText;
-        var cookieResetButtonText = options.cookieResetButtonText;
-        var cookieWhatAreLinkText = options.cookieWhatAreLinkText;
-        var cookieNotificationLocationBottom = options.cookieNotificationLocationBottom;
-        var cookiePolicyPage = options.cookiePolicyPage;
-        var cookiePolicyPageMessage = options.cookiePolicyPageMessage;
-        var cookieDiscreetLink = options.cookieDiscreetLink;
-        var cookieDiscreetReset = options.cookieDiscreetReset;
-        var cookieDiscreetLinkText = options.cookieDiscreetLinkText;
-        var cookieDiscreetPosition = options.cookieDiscreetPosition;
-        var cookieNoMessage = options.cookieNoMessage;
-        // cookie identifier
-        var $cookieAccepted = $.cookie('cc_cookie_accept') == "cc_cookie_accept";
-        $.cookieAccepted = function () {
-            return $cookieAccepted;
-        };
-        var $cookieDeclined = $.cookie('cc_cookie_decline') == "cc_cookie_decline";
-        $.cookieDeclined = function () {
-            return $cookieDeclined;
-        };
-        // write cookie accept button
-        if (cookieAcceptButton) {
-            var cookieAccept = ' <a href="#accept" class="cc-cookie-accept">' + cookieAcceptButtonText + '</a> ';
-        } else {
-            var cookieAccept = "";
-        }
-        // write cookie decline button
-        if (cookieDeclineButton) {
-            var cookieDecline = ' <a href="#decline" class="cc-cookie-decline">' + cookieDeclineButtonText + '</a> ';
-        } else {
-            var cookieDecline = "";
-        }
-        // write extra class for overlay
-        if (cookieOverlayEnabled) {
-            var cookieOverlay = 'cc-overlay';
-        } else {
-            var cookieOverlay = "";
-        }
-        // to prepend or append, that is the question?
-        if ((cookieNotificationLocationBottom) || (cookieDiscreetPosition == "bottomright") || (cookieDiscreetPosition == "bottomleft")) {
-            var appOrPre = true;
-        } else {
-            var appOrPre = false;
-        }
-        if (($cookieAccepted) || ($cookieDeclined)) {
-            // write cookie reset button
-            if ((cookieResetButton) && (cookieDiscreetReset)) {
-                if (appOrPre) {
-                    $('body').append('<div class="cc-cookies cc-discreet"><a class="cc-cookie-reset" href="#" title="' + cookieResetButtonText + '">' + cookieResetButtonText + '</a></div>');
-                } else {
-                    $('body').prepend('<div class="cc-cookies cc-discreet"><a class="cc-cookie-reset" href="#" title="' + cookieResetButtonText + '">' + cookieResetButtonText + '</a></div>');
-                }
-                //add appropriate CSS depending on position chosen
-                if (cookieDiscreetPosition == "topleft") {
-                    $('div.cc-cookies').css("top", "0");
-                    $('div.cc-cookies').css("left", "0");
-                }
-                if (cookieDiscreetPosition == "topright") {
-                    $('div.cc-cookies').css("top", "0");
-                    $('div.cc-cookies').css("right", "0");
-                }
-                if (cookieDiscreetPosition == "bottomleft") {
-                    $('div.cc-cookies').css("bottom", "0");
-                    $('div.cc-cookies').css("left", "0");
-                }
-                if (cookieDiscreetPosition == "bottomright") {
-                    $('div.cc-cookies').css("bottom", "0");
-                    $('div.cc-cookies').css("right", "0");
-                }
-            } else if (cookieResetButton) {
-                if (appOrPre) {
-                    $('body').append('<div class="cc-cookies"><a href="#" class="cc-cookie-reset">' + cookieResetButtonText + '</a></div>');
-                } else {
-                    $('body').prepend('<div class="cc-cookies"><a href="#" class="cc-cookie-reset">' + cookieResetButtonText + '</a></div>');
-                }
-            } else {
-                var cookieResetButton = "";
-            }
-        } else {
-            // add message to just after opening body tag
-            if ((cookieNoMessage) && (!cookiePolicyPage)) {
-                // show no link on any pages APART from the policy page
-            } else if ((cookieDiscreetLink) && (!cookiePolicyPage)) { // show discreet link
-                if (appOrPre) {
-                    $('body').append('<div class="cc-cookies cc-discreet"><a href="' + cookiePolicyLinkIn + '" title="' + cookieDiscreetLinkText + '">' + cookieDiscreetLinkText + '</a></div>');
-                } else {
-                    $('body').prepend('<div class="cc-cookies cc-discreet"><a href="' + cookiePolicyLinkIn + '" title="' + cookieDiscreetLinkText + '">' + cookieDiscreetLinkText + '</a></div>');
-                }
-                //add appropriate CSS depending on position chosen
-                if (cookieDiscreetPosition == "topleft") {
-                    $('div.cc-cookies').css("top", "0");
-                    $('div.cc-cookies').css("left", "0");
-                }
-                if (cookieDiscreetPosition == "topright") {
-                    $('div.cc-cookies').css("top", "0");
-                    $('div.cc-cookies').css("right", "0");
-                }
-                if (cookieDiscreetPosition == "bottomleft") {
-                    $('div.cc-cookies').css("bottom", "0");
-                    $('div.cc-cookies').css("left", "0");
-                }
-                if (cookieDiscreetPosition == "bottomright") {
-                    $('div.cc-cookies').css("bottom", "0");
-                    $('div.cc-cookies').css("right", "0");
-                }
-            } else if (cookieAnalytics) { // show analytics overlay
-                if (appOrPre) {
-                    $('body').append('<div class="cc-cookies ' + cookieOverlay + '">' + cookieAnalyticsMessage + cookieAccept + cookieDecline + '<a href="' + cookieWhatAreTheyLink + '" title="Visit All about cookies (External link)">' + cookieWhatAreLinkText + '</a></div>');
-                } else {
-                    $('body').prepend('<div class="cc-cookies ' + cookieOverlay + '">' + cookieAnalyticsMessage + cookieAccept + cookieDecline + '<a href="' + cookieWhatAreTheyLink + '" title="Visit All about cookies (External link)">' + cookieWhatAreLinkText + '</a></div>');
-                }
-            }
-            if (cookiePolicyPage) { // show policy page overlay
-                if (appOrPre) {
-                    $('body').append('<div class="cc-cookies ' + cookieOverlay + '">' + cookiePolicyPageMessage + " " + ' <a href="#accept" class="cc-cookie-accept">' + cookieAcceptButtonText + '</a> ' + ' <a href="#decline" class="cc-cookie-decline">' + cookieDeclineButtonText + '</a> ' + '</div>');
-                } else {
-                    $('body').prepend('<div class="cc-cookies ' + cookieOverlay + '">' + cookiePolicyPageMessage + " " + ' <a href="#accept" class="cc-cookie-accept">' + cookieAcceptButtonText + '</a> ' + ' <a href="#decline" class="cc-cookie-decline">' + cookieDeclineButtonText + '</a> ' + '</div>');
-                }
-            } else if ((!cookieAnalytics) && (!cookieDiscreetLink)) { // show privacy policy option
-                if (appOrPre) {
-                    $('body').append('<div class="cc-cookies ' + cookieOverlay + '">' + cookieMessage + cookieAccept + cookieDecline + '</div>');
-                } else {
-                    $('body').prepend('<div class="cc-cookies ' + cookieOverlay + '">' + cookieMessage + cookieAccept + cookieDecline + '</div>');
-                }
-            }
-        }
-        if ((cookieCutter) && (!cookieCutterDeclineOnly) && (($cookieDeclined) || (!$cookieAccepted))) {
-            $(cookieDisable).html('<div class="cc-cookies-error">' + cookieErrorMessage + ' <a href="#accept" class="cc-cookie-accept">' + cookieAcceptButtonText + '</a> ' + '</div>');
-        }
-        if ((cookieCutter) && (cookieCutterDeclineOnly) && ($cookieDeclined)) {
-            $(cookieDisable).html('<div class="cc-cookies-error">' + cookieErrorMessage + ' <a href="#accept" class="cc-cookie-accept">' + cookieAcceptButtonText + '</a> ' + '</div>');
-        }
-        // if bottom is true, switch div to bottom if not in discreet mode
-        if ((cookieNotificationLocationBottom) && (!cookieDiscreetLink)) {
-            $('div.cc-cookies').css("top", "auto");
-            $('div.cc-cookies').css("bottom", "0");
-        }
-        if ((cookieNotificationLocationBottom) && (cookieDiscreetLink) && (cookiePolicyPage)) {
-            $('div.cc-cookies').css("top", "auto");
-            $('div.cc-cookies').css("bottom", "0");
-        }
-        // setting the cookies
 
-        // for top bar
+        options               = $.extend({}, defaults, options);
+        options.cookieMessage = options.cookieMessage.replace('{{cookiePolicyLink}}', options.cookiePolicyLink);
+
+        // cookie identifier
+        var $cookieAccepted = $.cookie('cc_cookie_accept')  == 'cc_cookie_accept';
+        var $cookieDeclined = $.cookie('cc_cookie_decline') == 'cc_cookie_decline';
+
+        $.cookieAccepted = function () { return $cookieAccepted; };
+        $.cookieDeclined = function () { return $cookieDeclined; };
+
+        //  buttons html-string, etc
+        var cookieAccept  = '',
+            cookieDecline = '',
+            cookieOverlay = ''
+        ;
+
+        if (options.cookieAcceptButton)  // write cookie accept button
+            cookieAccept  = ' <a href="#accept" class="cc-cookie-accept">' + options.cookieAcceptButtonText + '</a> ';
+
+
+        if (options.cookieDeclineButton) // write cookie decline button
+            cookieDecline = ' <a href="#decline" class="cc-cookie-decline">' + options.cookieDeclineButtonText + '</a> ';
+
+        // write extra class for overlay
+        if (options.cookieOverlayEnabled)
+            cookieOverlay = ' cc-overlay';
+
+        // to prepend or append, that is the question?
+        var appOrPre = (options.cookieNotificationLocationBottom         ||
+                        options.cookieDiscreetPosition == "bottomright"  ||
+                        options.cookieDiscreetPosition == "bottomleft") ? 'append' : 'prepend';
+
+        var setDiscretePos = function(pos) {
+            //add appropriate CSS depending on position chosen
+            switch (pos) {
+                case 'topleft'    : $('div.cc-cookies').css({top: 0,    left: 0});  break;
+                case 'topright'   : $('div.cc-cookies').css({top: 0,    right: 0}); break;
+                case 'bottomleft' : $('div.cc-cookies').css({bottom: 0, left: 0});  break;
+                case 'bottomright': $('div.cc-cookies').css({bottom: 0, right: 0}); break;
+            }
+        };
+
+        if ($cookieAccepted || $cookieDeclined) {
+            // write cookie reset button
+            if (options.cookieResetButton && options.cookieDiscreetReset) {
+                $('body')[appOrPre]('<div class="cc-cookies cc-discreet"><a href="#" class="cc-cookie-reset">' + cookieResetButtonText + '</a></div>');
+                setDiscrete(options.cookieDiscreetPosition);
+            } else if (options.cookieResetButton) {
+                $('body')[appOrPre]('<div class="cc-cookies"><a href="#" class="cc-cookie-reset">' + options.cookieResetButtonText + '</a></div>');
+            }
+        } else if (options.cookieNoMessage && !options.cookiePolicyPage) {
+            // show no link on any pages APART from the policy page
+        } else if (options.cookieDiscreetLink && !options.cookiePolicyPage) { // show discreet link
+            $('body')[appOrPre]('<div class="cc-cookies cc-discreet"><a href="' + options.cookiePolicyLink + '" title="' + options.cookieDiscreetLinkText + '">' + options.cookieDiscreetLinkText + '</a></div>');
+            setDiscrete(options.cookieDiscreetPosition);
+        } else if (options.cookieAnalytics) { // show analytics overlay
+            $('body')[appOrPre]('<div class="cc-cookies' + cookieOverlay + '">' + options.cookieAnalyticsMessage + cookieAccept + cookieDecline + '<a rel="external" href="' + options.cookieWhatAreTheyLink + '">' + options.cookieWhatAreLinkText + '</a></div>');
+        }
+
+        if (options.cookiePolicyPage) { // show policy page overlay
+            $('body')[appOrPre]('<div class="cc-cookies' + cookieOverlay + '">' + options.cookiePolicyPageMessage + " " + ' <a href="#accept" class="cc-cookie-accept">' + options.cookieAcceptButtonText + '</a> ' + ' <a href="#decline" class="cc-cookie-decline">' + options.cookieDeclineButtonText + '</a> ' + '</div>');
+        } else if (!options.cookieAnalytics && !options.cookieDiscreetLink) { // show privacy policy option
+            $('body')[appOrPre]('<div class="cc-cookies' + cookieOverlay + '">' + options.cookieMessage + cookieAccept + cookieDecline + '</div>');
+        }
+
+        if ((options.cookieCutter && !options.cookieCutterDeclineOnly && ($cookieDeclined || !$cookieAccepted)) ||
+            (options.cookieCutter && options.cookieCutterDeclineOnly && $cookieDeclined)
+        ) $(cookieDisable).html('<div class="cc-cookies-error">' + options.cookieErrorMessage + ' <a href="#accept" class="cc-cookie-accept">' + options.cookieAcceptButtonText + '</a> ' + '</div>');
+
+        // if bottom is true, switch div to bottom if not in discreet mode
+        if ((options.cookieNotificationLocationBottom && !options.cookieDiscreetLink) ||
+            (options.cookieNotificationLocationBottom && options.cookieDiscreetLink && options.cookiePolicyPage)
+        ) $('div.cc-cookies').css({top: 'auto', bottom: 0});
+
+        // click handlers, setting the cookies ...
+
+        // handler: for [top/bottom] bar
         $('.cc-cookie-accept, .cc-cookie-decline').click(function (e) {
             e.preventDefault();
+
             if ($(this).is('[href$=#decline]')) {
-                $.cookie("cc_cookie_accept", null, {
-                    path: '/'
-                });
-                $.cookie("cc_cookie_decline", "cc_cookie_decline", {
-                    expires: cookieExpires,
-                    path: '/'
-                });
+                $.cookie('cc_cookie_accept', null, { path: '/' });
+                $.cookie('cc_cookie_decline', 'cc_cookie_decline', { expires: options.cookieExpires, path: '/'});
+
                 if (options.cookieDomain) {
                     // kill google analytics cookies
-                    $.cookie("__utma", null, {
-                        domain: '.' + options.cookieDomain,
-                        path: '/'
-                    });
-                    $.cookie("__utmb", null, {
-                        domain: '.' + options.cookieDomain,
-                        path: '/'
-                    });
-                    $.cookie("__utmc", null, {
-                        domain: '.' + options.cookieDomain,
-                        path: '/'
-                    });
-                    $.cookie("__utmz", null, {
-                        domain: '.' + options.cookieDomain,
-                        path: '/'
-                    });
+                    $.cookie("__utma", null, { domain: '.' + options.cookieDomain, path: '/' });
+                    $.cookie("__utmb", null, { domain: '.' + options.cookieDomain, path: '/' });
+                    $.cookie("__utmc", null, { domain: '.' + options.cookieDomain, path: '/' });
+                    $.cookie("__utmz", null, { domain: '.' + options.cookieDomain, path: '/' });
                 }
             } else {
-                $.cookie("cc_cookie_decline", null, {
-                    path: '/'
-                });
-                $.cookie("cc_cookie_accept", "cc_cookie_accept", {
-                    expires: cookieExpires,
-                    path: '/'
-                });
+                $.cookie('cc_cookie_decline', null, { path: '/' });
+                $.cookie('cc_cookie_accept', 'cc_cookie_accept', { expires: options.cookieExpires, path: '/' });
             }
+
             $(".cc-cookies").fadeOut(function () {
-                // reload page to activate cookies
                 location.reload();
             });
         });
-        //reset cookies
+
+        // handler: reset cookies
         $('a.cc-cookie-reset').click(function (f) {
             f.preventDefault();
-            $.cookie("cc_cookie_accept", null, {
-                path: '/'
-            });
-            $.cookie("cc_cookie_decline", null, {
-                path: '/'
-            });
+
+            $.cookie('cc_cookie_accept', null,  { path: '/' });
+            $.cookie('cc_cookie_decline', null, { path: '/' });
+
             $(".cc-cookies").fadeOut(function () {
-                // reload page to activate cookies
                 location.reload();
             });
         });
-        //cookie error accept
+
+        // handler: cookie error accept
         $('.cc-cookies-error a.cc-cookie-accept').click(function (g) {
             g.preventDefault();
-            $.cookie("cc_cookie_accept", "cc_cookie_accept", {
-                expires: cookieExpires,
-                path: '/'
-            });
-            $.cookie("cc_cookie_decline", null, {
-                path: '/'
-            });
-            // reload page to activate cookies
+
+            $.cookie('cc_cookie_accept', 'cc_cookie_accept', { expires: options.cookieExpires, path: '/'});
+            $.cookie('cc_cookie_decline', null, { path: '/'});
+
             location.reload();
         });
     };


### PR DESCRIPTION
hi again,

not the most handy PR (seeing as I made to functional tweak on top of a refactor of the code I did, namely: https://github.com/weare2ndfloor/cookieCuttr/pull/11).

the idea behind making the cookie name settable via an option is twofold:
- makes it easy to use acceptance cookies on different site sections and or subdomains 
- allows cookie acceptance to be forcibly reset (possibly desired/required as part of a policy change) even when someone has previously accepted cookies

... granted making the cookie value settable is a bit bogus but it might allow someone to save a few bytes :) 
