### PR TITLE
Update jquery.cookiecuttr.js, do not show if navigator.CookiesOK is set

### DIFF
--- a/jquery.cookiecuttr.js
+++ b/jquery.cookiecuttr.js
@@ -84,7 +84,7 @@
         var cookieDiscreetPosition = options.cookieDiscreetPosition;
         var cookieNoMessage = options.cookieNoMessage;
         // cookie identifier
-        var $cookieAccepted = $.cookie('cc_cookie_accept') == "cc_cookie_accept";
+        var $cookieAccepted = $.cookie('cc_cookie_accept') == "cc_cookie_accept" || !!navigator.CookiesOK;
         $.cookieAccepted = function () {
             return $cookieAccepted;
         };


### PR DESCRIPTION
If the user has installed CookiesOK to automatically accept all cookies navigator.CookiesOK will be set and the dialog should not be shown.
