### PR TITLE
wrap selector in quotes

### DIFF
--- a/jquery.cookiecuttr.js
+++ b/jquery.cookiecuttr.js
@@ -218,7 +218,7 @@
         // for top bar
         $('.cc-cookie-accept, .cc-cookie-decline').click(function (e) {
             e.preventDefault();
-            if ($(this).is('[href$=#decline]')) {
+            if ($(this).is("[href$='#decline']")) {
                 $.cookie("cc_cookie_accept", null, {
                     path: '/'
                 });


### PR DESCRIPTION
with later versions of jQuery, an error occurs when clicking the buttons: `Error: Syntax error, unrecognized expression: [href$=#decline]`